### PR TITLE
Fixes

### DIFF
--- a/jekyll-multisite.gemspec
+++ b/jekyll-multisite.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.license = 'GPL-3.0'
   s.files = ['lib/jekyll-multisite.rb']
   s.add_runtime_dependency 'jekyll', '~> 3.0', '>= 3.0.1'
+  s.add_runtime_dependency 'jekyll-paginate', '~> 1.1.0'
 end

--- a/lib/jekyll-multisite.rb
+++ b/lib/jekyll-multisite.rb
@@ -34,7 +34,9 @@ module Jekyll
        base_directory
      elsif questionable_path.start_with?(base_directory)
        questionable_path
-     elsif File.exists?(questionable_path) and !questionable_path.start_with?('/')
+     elsif File.exists?(questionable_path) and !questionable_path.start_with?('/') and (ENV['OS'] == 'Windows_NT')
+       File.expand_path(questionable_path)
+     elsif File.exists?(questionable_path) and questionable_path != '/' and !(ENV['OS'] == 'Windows_NT')
        File.expand_path(questionable_path)
      else
        File.join(base_directory, questionable_path)

--- a/lib/jekyll-multisite.rb
+++ b/lib/jekyll-multisite.rb
@@ -34,7 +34,7 @@ module Jekyll
        base_directory
      elsif questionable_path.start_with?(base_directory)
        questionable_path
-     elsif File.exists?(questionable_path) and questionable_path != '/'
+     elsif File.exists?(questionable_path) and !questionable_path.start_with?('/')
        File.expand_path(questionable_path)
      else
        File.join(base_directory, questionable_path)

--- a/lib/jekyll-multisite.rb
+++ b/lib/jekyll-multisite.rb
@@ -46,7 +46,7 @@ module Jekyll
   class Cleaner
     def parent_dirs(file)
       parent_dir = File.dirname(file)
-      if parent_dir == '/'
+      if parent_dir == '/' or File.dirname(parent_dir) == parent_dir or !parent_dir.start_with?(site.dest)
         []
       elsif parent_dir == site.dest
         []


### PR DESCRIPTION
- If a subfolder A of a site folder is named like a folder B in the root (/), then the folder B is taken instead of A.
- Fix endless recursion and make sure we stay in site.dest on Windows
